### PR TITLE
Update TemplateMailableRenderer.php

### DIFF
--- a/src/TemplateMailableRenderer.php
+++ b/src/TemplateMailableRenderer.php
@@ -80,6 +80,8 @@ class TemplateMailableRenderer
             '{{{ body }}}',
             '{{body}}',
             '{{ body }}',
+            '{{ $body }}',
+            '{!! $body !!}',
         ])) {
             throw CannotRenderTemplateMailable::layoutDoesNotContainABodyPlaceHolder($this->templateMailable);
         }


### PR DESCRIPTION
Allow html to be rendered in blade templates. Having `{{ body }}` in the blade template would throw the following error:

    Use of undefined constant body - assumed 'body' (this will throw an Error in a future version of PHP)