### PR TITLE
README update to include blade content rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,8 @@ You can extend the `getHtmlLayout()` method on either a template mailable or a m
 
 When sending a `TemplateMailable` the compiled template will be rendered inside of the `{{{ body }}}` placeholder in the layout before being sent.
 
+If using a Blade view, the placeholder will need to be `@{{{ body }}}`.
+
 The following example will send a `WelcomeMail` using a template wrapped in a layout.
 
 ```php


### PR DESCRIPTION
Updated the README.md to include `@{{{ body }}}` should be used when the wrapping template is being pulled from a blade file.

Seen in the discussions this has caused a bit of confusion (simple but could save some headache for beginners)