### PR TITLE
Added overload function for allowing dynamic properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,26 @@ class WelcomeMail extends TemplateMailable
 
 By extending the `\Spatie\MailTemplates\TemplateMailable` class this mailable will be rendered using the corresponding `MailTemplate`. All public properties on the `WelcomeMail` will be available in the template.
 
+If you need to use properties within your template that are initially defined within your `WelcomeMail` (for example, data that comes from another source). You can call `$this->setAdditionalData()` and pass it an array of you additional key => value pairs.
+
+An example of this would be:
+```php
+namespace App\Mail;
+
+use TemplateMailable;
+
+class WelcomeMail extends TemplateMailable
+{
+
+    public function __construct(User $user)
+    {
+        $this->setAdditionalData([
+            'name' => 'Joe Bloggs'
+        ]);
+    }
+}
+```
+
 ### Customizing the `MailTemplate` model
 
 The default `MailTemplate` model is sufficient for using _one_ database mail template for _one_ mailable. If you want to use multiple mail templates for the same mailable _or_ extend the `MailTemplate` model, we highly encourage you to publish the `mail_template` migration and create your own mail template model by extending `MailTemplate`. Make sure to implement the `MailTemplateInterface` interface as well.

--- a/src/TemplateMailable.php
+++ b/src/TemplateMailable.php
@@ -118,10 +118,7 @@ abstract class TemplateMailable extends Mailable
     public function buildViewData(): array
     {
         $mailablePropeties = parent::buildViewData();
-        if(is_null($this->additionalData)) {
-            return $mailablePropeties;
-        }
-        return array_merge($mailablePropeties, $this->additionalData);
+        return array_merge($mailablePropeties, $this->additionalData ?? []);
     }
 
     public function setAdditionalData($array) {

--- a/src/TemplateMailable.php
+++ b/src/TemplateMailable.php
@@ -17,6 +17,9 @@ abstract class TemplateMailable extends Mailable
     /** @var MailTemplateInterface */
     protected $mailTemplate;
 
+    /** @var array */
+    protected $additionalData;
+
     public static function getVariables(): array
     {
         return static::getPublicProperties();
@@ -110,5 +113,18 @@ abstract class TemplateMailable extends Mailable
     protected function getMailTemplateRenderer(): TemplateMailableRenderer
     {
         return app(TemplateMailableRenderer::class, ['templateMailable' => $this]);
+    }
+
+    public function buildViewData(): array
+    {
+        $mailablePropeties = parent::buildViewData();
+        if(is_null($this->additionalData)) {
+            return $mailablePropeties;
+        }
+        return array_merge($mailablePropeties, $this->additionalData);
+    }
+
+    public function setAdditionalData($array) {
+        $this->additionalData = $array;
     }
 }


### PR DESCRIPTION
Adds the ability to pass an array into the available so the additional data can be used along side the public properties.
Personally had a use case where this was needed as I needed to pass data in from multiple different sources depending on user actions.

Happy to amend if needed just let me know. Thought it would be useful since I also saw a closed issue relating to a similar scenario.

Similar to closed issue: https://github.com/spatie/laravel-database-mail-templates/issues/29